### PR TITLE
add focusChar documentation to all focusable widgets 

### DIFF
--- a/content/modules/gerrit.md
+++ b/content/modules/gerrit.md
@@ -108,6 +108,9 @@ Value: Your <a href="https://gerrit-review.googlesource.com/Documentation/user-u
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `projects` <br />
 A list of Gerrit project names to fetch data for. <br />
 

--- a/content/modules/git.md
+++ b/content/modules/git.md
@@ -85,6 +85,9 @@ Values: `true`, `false`.
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `refreshInterval` <br />
 How often, in seconds, this module will update its data. <br />
 Values: A positive integer, `0..n`.

--- a/content/modules/github.md
+++ b/content/modules/github.md
@@ -85,6 +85,9 @@ Values: `true`, `false`.
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `refreshInterval` <br />
 How often, in seconds, this module will update its data. <br />
 Values: A positive integer, `0..n`.

--- a/content/modules/gitlab.md
+++ b/content/modules/gitlab.md
@@ -72,6 +72,9 @@ Values: `true`, `false`.
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `refreshInterval` <br />
 How often, in seconds, this module will update its data. <br />
 Values: A positive integer, `0..n`.

--- a/content/modules/gitter.md
+++ b/content/modules/gitter.md
@@ -66,6 +66,9 @@ Maximum number of _(newest)_ messages to be displayed. Default is `10`<br />
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `roomUri` <br />
 _Optional_ <br /
 URI of the room you would like to see the chat messages from. Default is `wtfutil/Lobby`<br />

--- a/content/modules/google/gcal.md
+++ b/content/modules/google/gcal.md
@@ -108,6 +108,9 @@ Values: `true`, or `false`
 `position` <br />
 Where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `refreshInterval` <br />
 How often, in seconds, this module will update its data. <br />
 Values: A positive integer, `0..n`.

--- a/content/modules/hackernews.md
+++ b/content/modules/hackernews.md
@@ -65,6 +65,9 @@ Defines number of stories to be displayed. Default is `10`<br />
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `storyType` <br />
 _Optional_ <br /
 Defines type of stories to be displayed. Default is `top` stories<br />

--- a/content/modules/jenkins.md
+++ b/content/modules/jenkins.md
@@ -66,6 +66,9 @@ Values: `true`, `false`.
 `position` <br />
 Defines where in the grid this module's widget will be displayed.
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `refreshInterval` <br />
 How often, in seconds, this module will update its data. <br />
 Values: A positive integer, `0..n`.

--- a/content/modules/jira.md
+++ b/content/modules/jira.md
@@ -120,6 +120,9 @@ Values: See <a href="https://confluence.atlassian.com/jiracore/blog/2015/07/sear
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `project` <br />
 The Jira project to fetch information for. <br />
 

--- a/content/modules/logger.md
+++ b/content/modules/logger.md
@@ -50,6 +50,9 @@ Values: `true`, `false`.
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `refreshInterval` <br />
 How often, in seconds, this module will update its data. <br />
 Values: A positive integer, `0..n`.

--- a/content/modules/mercurial.md
+++ b/content/modules/mercurial.md
@@ -80,6 +80,9 @@ Values: `true`, `false`.
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `refreshInterval` <br />
 How often, in seconds, this module will update its data. <br />
 Values: A positive integer, `0..n`.

--- a/content/modules/spotify.md
+++ b/content/modules/spotify.md
@@ -50,6 +50,9 @@ Values: `true`, `false`.
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `refreshInterval` <br />
 How often, in seconds, this module will update its data. <br />
 Values: A positive integer, `0..n`.

--- a/content/modules/textfile.md
+++ b/content/modules/textfile.md
@@ -64,6 +64,9 @@ Default: `vim`.
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `refreshInterval` <br />
 How often, in seconds, this module will update its data. <br />
 Values: A positive integer, `0..n`.

--- a/content/modules/todo.md
+++ b/content/modules/todo.md
@@ -107,6 +107,9 @@ Values: Any valid filename, ideally ending in `yml`.
 `position` <br />
 Where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `refreshInterval` <br />
 How often, in seconds, this module will update its data. <br />
 Values: A positive integer, `0..n`.

--- a/content/modules/todoist.md
+++ b/content/modules/todoist.md
@@ -80,6 +80,9 @@ Values: `true`, `false`.
 `position` <br />
 Where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `projects` <br />
 The todoist projects to fetch items from. <br />
 Values: The integer ID of the project.

--- a/content/modules/travisci.md
+++ b/content/modules/travisci.md
@@ -64,6 +64,9 @@ Values: `true`, `false`.
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `pro` <br />
 Determines whether or not this module will use the Pro version of Travis CI.<br />
 Values: `true`, `false`.

--- a/content/modules/twitter.md
+++ b/content/modules/twitter.md
@@ -52,6 +52,9 @@ Values: `true`, `false`.
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `refreshInterval` <br />
 How often, in seconds, this module will update its data. <br />
 Values: Any positive integer, `0..n`.

--- a/content/modules/weather_services/weather.md
+++ b/content/modules/weather_services/weather.md
@@ -85,6 +85,9 @@ Values: Any <a href="https://openweathermap.org/current">language identifier</a>
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `refreshInterval` <br />
 How often, in seconds, this module will update its data. <br />
 Values: A positive integer, `0..n`.

--- a/content/modules/zendesk.md
+++ b/content/modules/zendesk.md
@@ -60,6 +60,9 @@ Values: `true`, `false`.
 `position` <br />
 Defines where in the grid this module's widget will be displayed. <br />
 
+`focusChar` <br />
+Define one of the number keys as a short cut key to access the widget. <br />
+
 `status` <br />
 The status of tickets you want to retrieve.
 Values: `new`, `open`, `pending`, `hold`.


### PR DESCRIPTION
I added the focusChar within the documentation for all the widgets that are focusable. 
Do I have to generate the documentation or will you do this on the next release?