### PR TITLE
Fix prettyweather example so that it's valid

### DIFF
--- a/content/modules/weather_services/prettyweather.md
+++ b/content/modules/weather_services/prettyweather.md
@@ -21,7 +21,7 @@ Displays weather information as ASCII art from [Wttr.in](http://wttr.in).
         height: 1
         width: 1
       refreshInterval: 300
-      unit: "c"
+      unit: "m"
       view: 0
       language: "en"
 ```


### PR DESCRIPTION
I copy/pasted the example and it's invalid. Should be `m` instead of `c`. Seems like something other people will do