### PR TITLE
Remove overflow-y to use default scrolling on iOS

### DIFF
--- a/themes/docdock/static/scss/flex/article.scss
+++ b/themes/docdock/static/scss/flex/article.scss
@@ -16,10 +16,7 @@ article section.page {
     flex: 1;
     box-sizing: border-box;
     margin: 0 1rem 0 20rem;
-    overflow-y: auto;
     padding: 2rem 4rem;
-
-
 
     h1:first-of-type {
         margin: 3rem 0rem;

--- a/themes/docdock/static/theme-flex/style.css
+++ b/themes/docdock/static/theme-flex/style.css
@@ -303,7 +303,6 @@ article section.page {
   flex: 1;
   box-sizing: border-box;
   margin: 0 1rem 0 20rem;
-  overflow-y: auto;
   padding: 2rem 4rem; }
   article section.page h1:first-of-type {
     margin: 3rem 0rem;


### PR DESCRIPTION
Fix for #33 