### PR TITLE
content/modules/github.md: Fix keyboard char to select previous item

### DIFF
--- a/content/modules/github.md
+++ b/content/modules/github.md
@@ -82,7 +82,7 @@ github:
   {{< keyboard/spacer >}}
 
   {{< keyboard/arrowUp desc="Select the next item in the list" >}}
-  {{< keyboard/arrowBack desc="Select the previous item in the list" >}}
+  {{< keyboard/arrowDown desc="Select the previous item in the list" >}}
   {{< keyboard/arrowBack desc="Show the previous git repository" >}}
   {{< keyboard/arrowFore desc="Show the next git repository" >}}
 {{% /keyboard %}}


### PR DESCRIPTION
There is a typo that refers to keyboard/arrowBack for selecting
previous item in a list. This should be keybaord/arrowDown instead.