### PR TITLE
Add Buildkite documentation

### DIFF
--- a/content/modules/buildkite.md
+++ b/content/modules/buildkite.md
@@ -1,0 +1,46 @@
+---
+title: "Buildkite"
+date: 2019-10-10T11:07:37-07:00
+draft: false
+weight: 10
+---
+
+Connects to the [Buildkite](https://buildkite.com) REST API and displays status of branches for configured Pipelines.
+
+The API token must have the `read_builds` permission.
+
+## Configuration
+
+```yaml
+buildkite:
+  apiKey: "3276d7155dd9ee27b8b14f8743a408a9"
+  enabled: true
+  organizationSlug: "acme-corp"
+  refreshInterval: 60
+  position:
+    top: 1
+    left: 1
+    height: 1
+    width: 1
+  pipelines:
+    pipeline-slug-1:
+      branches:
+        - "master"
+        - "stage"
+    pipeline-slug-2:
+      branches:
+        - "master"
+        - "production"
+```
+
+{{% attributes %}}
+  {{< attributes/apikey name="Buildkite" link="https://buildkite.com/docs/apis/rest-api#authentication" envvar="WTF_BUILDKITE_TOKEN" >}}
+  {{< attributes/border >}}
+  {{< attributes/enabled >}}
+  {{< attributes/position >}}
+  {{< attributes/refreshInterval >}}
+  {{< attributes/custom name="organizationSlug" desc="The slug of your organization" value="`org.slug`" >}}
+  {{< attributes/custom name="pipelines" desc="A hash with `pipeline.slug` as keys, mapping to a list of branches" value="" >}}
+{{% /attributes %}}
+
+{{% sourcePath module="buildkite" %}}


### PR DESCRIPTION
Fixes #66 

Adds the documentation for the Buildkite widget.

Note: This should be merged after https://github.com/wtfutil/wtf/pull/686 is merged, so that this documentation properly matches the `apiKey` field in the configuration.

Thanks!