### PR TITLE
Create docs for the `twitterstats` module

### DIFF
--- a/content/modules/twitter/_index.md
+++ b/content/modules/twitter/_index.md
@@ -6,3 +6,5 @@ weight: 120
 ---
 
 Modules that interact with the Twitter API to display data.
+
+{{% children %}}

--- a/content/modules/twitter/_index.md
+++ b/content/modules/twitter/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Twitter"
+date: 2019-10-29T03:26:02-08:00
+draft: false
+weight: 120
+---
+
+Modules that interact with the Twitter API to display data.

--- a/content/modules/twitter/twitterstats.md
+++ b/content/modules/twitter/twitterstats.md
@@ -1,0 +1,70 @@
+---
+title: "Twitter Stats"
+date: 2018-07-31T20:21:37-07:00
+draft: false
+weight: 40
+---
+
+Connects to the Twitter API and displays statistics about the number of tweets and followers for a set of usernames.
+
+![](https://ameo.link/u/6o5.png)
+
+To make this work, you'll need a couple of things:
+
+1. A [Twitter developer account](https://developer.twitter.com/content/developer-twitter/en.html)
+
+... and one of the following:
+
+a) A [Twitter bearer token](https://developer.twitter.com/en/docs/basics/authentication/overview/application-only)<br/>
+b) [Consumer API keys](https://developer.twitter.com/en/docs/basics/authentication/guides/access-tokens)
+
+You must have either a bearer token or consumer key + consumer secret provided.  To get the consumer API keys, you must first create a Twitter application.  Then, go to the "Keys and tokens" page and copy the API key and API secret key under the Consumer API keys section:
+
+![](https://ameo.link/u/6p1.png)
+
+Once you have your developer account, a relatively painless way to get a
+bearer token is to use [TBT](https://github.com/Trinergy/twitter_bearer_token).
+
+## Configuration
+
+```yaml
+twitterstats:
+  consumerKey: "3276d7155dd9ee27b8b14f8743a408a9"
+  consumerSecret: "3276d7155dd9ee27b8b14f8743a408a9"
+  enabled: true
+  position:
+    top: 0
+    left: 1
+    height: 1
+    width: 1
+  refreshInterval: 20000
+  screenNames:
+  - "wtfutil"
+  - "dril"
+```
+
+{{% attributes %}}
+  <tr>
+    <td>`bearerToken`</td>
+    <td>_Optional_ Your <a href="https://developer.twitter.com/en/docs/basics/authentication/overview/application-only.html">Twitter single-application Bearer Token.  This must be supplied if `consumerKey` and `consumerSecret` are not.</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>`consumerKey`</td>
+    <td>_Optional_ Your Twitter Consumer API secret.  This must be supplied along with `consumerSecret` if `bearerToken` isn't supplied.</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>`consumerSecret`</td>
+    <td>_Optional_ Your Twitter Consumer API key.  This must be supplied along with `consumerKey` if `bearerToken` isn't supplied.</td>
+    <td></td>
+  </tr>
+
+  {{< attributes/border >}}
+  {{< attributes/custom name="count" desc="_Optional_ The number of tweets to return per account. Default: 5." value="Any positive integer" >}}
+  {{< attributes/enabled >}}
+  {{< attributes/focusChar >}}
+  {{< attributes/position >}}
+  {{< attributes/refreshInterval >}}
+  {{< attributes/custom name="screenNames" desc="The screen names of the Twitter users who's tweets you want to follow." value="A list of any valid Twitter user's screen names" >}}
+{{% /attributes %}}

--- a/content/modules/twitter/twittertweets.md
+++ b/content/modules/twitter/twittertweets.md
@@ -12,7 +12,15 @@ NOTE: This only works for single-application developer accounts for now.
 To make this work, you'll need a couple of things:
 
 1. A [Twitter developer account](https://developer.twitter.com/content/developer-twitter/en.html)
-2. A [Twitter bearer token](https://developer.twitter.com/en/docs/basics/authentication/overview/application-only).
+
+... and one of the following:
+
+a) A [Twitter bearer token](https://developer.twitter.com/en/docs/basics/authentication/overview/application-only)<br/>
+b) [Consumer API keys](https://developer.twitter.com/en/docs/basics/authentication/guides/access-tokens)
+
+You must have either a bearer token or consumer key + consumer secret provided.  To get the consumer API keys, you must first create a Twitter application.  Then, go to the "Keys and tokens" page and copy the API key and API secret key under the Consumer API keys section:
+
+![](https://ameo.link/u/6p1.png)
 
 Once you have your developer account, a relatively painless way to get a
 bearer token is to use [TBT](https://github.com/Trinergy/twitter_bearer_token).
@@ -56,7 +64,17 @@ twitter:
 {{% attributes %}}
   <tr>
     <td>`bearerToken`</td>
-    <td>Your <a href="https://developer.twitter.com/en/docs/basics/authentication/overview/application-only.html">Twitter single-application Bearer Token</a></td>
+    <td>_Optional_ Your <a href="https://developer.twitter.com/en/docs/basics/authentication/overview/application-only.html">Twitter single-application Bearer Token.  This must be supplied if `consumerKey` and `consumerSecret` are not.</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>`consumerKey`</td>
+    <td>_Optional_ Your Twitter Consumer API secret.  This must be supplied along with `consumerSecret` if `bearerToken` isn't supplied.</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>`consumerSecret`</td>
+    <td>_Optional_ Your Twitter Consumer API key.  This must be supplied along with `consumerKey` if `bearerToken` isn't supplied.</td>
     <td></td>
   </tr>
 

--- a/content/modules/twitter/twittertweets.md
+++ b/content/modules/twitter/twittertweets.md
@@ -1,8 +1,8 @@
 ---
-title: "Twitter"
+title: "Twitter Tweets"
 date: 2018-07-31T20:21:37-07:00
 draft: false
-weight: 260
+weight: 50
 ---
 
 Connects to the Twitter API and displays a single user's tweets.
@@ -48,7 +48,7 @@ twitter:
     height: 1
     width: 1
   refreshInterval: 20000
-  screenNames: 
+  screenNames:
   - "golang"
   - "wtfutil"
 ```
@@ -83,8 +83,6 @@ twitter:
 
   {{< keyboard/spacer >}}
 
-  {{< keyboard/arrowBack desc="Show the previous Twitter account" >}} 
+  {{< keyboard/arrowBack desc="Show the previous Twitter account" >}}
   {{< keyboard/arrowFore desc="Show the next Twitter account" >}}
 {{% /keyboard %}}
-
-{{% sourcePath module="twitter" %}}


### PR DESCRIPTION
NOTE: I'm stuck with an issue where the generated Twitter index page contains content from the child pages that I simply can't get rid of:

![](https://ameo.link/u/6p2.png)

It seems to be trying to load content from the Twitter Tweets page even though it's very clearly not on it.  I've tried removing the `{{% children %}}` line, re-building from scratch, and more to no avail.  That will probably have to be fixed before deploying (assuming that this isn't some kind of problem with my environment).

----

Goes with https://github.com/wtfutil/wtf/pull/715

Create twitterstats module docs
    
 * Create twitter directory and move existing twitter module docs into it
   * Add `_index.md` file for the new twitter directory
 * Create docs for the twitterstats module
   * Almost entirely duplicated from the existing twitter module docs, but added info about both auth methods (bearer token and consumer API keys)
 * Add docs about both auth methods to twitter module page