### PR TITLE
Fix copy/paste error in gcal settings

### DIFF
--- a/content/modules/google/gcal.md
+++ b/content/modules/google/gcal.md
@@ -84,7 +84,7 @@ gcal:
   </tr>
 
 
-  {{< attributes/custom name="showDeclined" desc="_Optional_ Whether or not to show the location of the appointment. Default: true." value="true, false" >}}
+  {{< attributes/custom name="showDeclined" desc="_Optional_ Whether or not to display events you’ve declined to attend. Default: true." value="true, false" >}}
   {{< attributes/custom name="showEndTime" desc="_Optional_ Whether or not to display the event end time. Default: false." value="true, false" >}}
 
   {{< attributes/timezone >}}


### PR DESCRIPTION
Google Calendar module settings description has duplicated withLocation description for showDeclined option. This replaces that copy/paste error with the text from https://github.com/wtfutil/wtf/blob/1afaa2ba453986564b97f25f725f8d03ce7782b6/modules/gcal/settings.go#L37 for consistency.