### PR TITLE
Fix weather broken link on main page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -173,7 +173,7 @@ Then click on <a href="/modules">Modules</a> to see the complete list.
       </p>
     </div>
     <div class="card-footer">
-      <div class="centered"><a href="/modules/weather/" >view module</a></div>
+      <div class="centered"><a href="/modules/weather_services/weather/" >view module</a></div>
     </div>
   </div>
   <div class="card">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html><head>
-	<meta name="generator" content="Hugo 0.76.4" />
+	<meta name="generator" content="Hugo 0.76.5" />
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -876,7 +876,7 @@ Then click on <a href="/modules">Modules</a> to see the complete list.
       </p>
     </div>
     <div class="card-footer">
-      <div class="centered"><a href="/modules/weather/" >view module</a></div>
+      <div class="centered"><a href="/modules/weather_services/weather/" >view module</a></div>
     </div>
   </div>
   <div class="card">

--- a/docs/modules/sports/index.html
+++ b/docs/modules/sports/index.html
@@ -303,6 +303,24 @@
         
         <a class="nav-link p-0" href="/modules/google/"><h6>Google Apps</h6></a>
         <ul class="list-unstyled ml-2">
+        <li data-nav-id="/modules/google/gcal/" class="nav-item my-1">
+                
+                 <a href="/modules/google/gcal/" class="nav-link p-0">
+                    Google Calendar
+                </a>
+        </li>
+        <li data-nav-id="/modules/google/ganalytics/" class="nav-item my-1">
+                
+                 <a href="/modules/google/ganalytics/" class="nav-link p-0">
+                    Google Analytics
+                </a>
+        </li>
+        <li data-nav-id="/modules/google/gspreadsheet/" class="nav-item my-1">
+                
+                 <a href="/modules/google/gspreadsheet/" class="nav-link p-0">
+                    Google Spreadsheets
+                </a>
+        </li>
         </ul>
     </li>
         <li data-nav-id="/modules/hackernews/" class="nav-item my-1">

--- a/docs/modules/weather_services/index.html
+++ b/docs/modules/weather_services/index.html
@@ -140,6 +140,433 @@
         
         <a class="nav-link p-0" href="/modules/"><h6>Modules</h6></a>
         <ul class="list-unstyled ml-2">
+        <li data-nav-id="/modules/azure_devops/" class="nav-item my-1">
+                
+                 <a href="/modules/azure_devops/" class="nav-link p-0">
+                    Azure DevOps
+                </a>
+        </li>
+        <li data-nav-id="/modules/bamboohr/" class="nav-item my-1">
+                
+                 <a href="/modules/bamboohr/" class="nav-link p-0">
+                    BambooHR
+                </a>
+        </li>
+        <li data-nav-id="/modules/buildkite/" class="nav-item my-1">
+                
+                 <a href="/modules/buildkite/" class="nav-link p-0">
+                    Buildkite
+                </a>
+        </li>
+    <li data-nav-id="/modules/cds/" class="nav-item my-1 haschildren
+        ">
+        
+        <a class="nav-link p-0" href="/modules/cds/"><h6>CDS</h6></a>
+        <ul class="list-unstyled ml-2">
+        <li data-nav-id="/modules/cds/favorites/" class="nav-item my-1">
+                
+                 <a href="/modules/cds/favorites/" class="nav-link p-0">
+                    CDS Favorites
+                </a>
+        </li>
+        <li data-nav-id="/modules/cds/queue/" class="nav-item my-1">
+                
+                 <a href="/modules/cds/queue/" class="nav-link p-0">
+                    CDS Queue
+                </a>
+        </li>
+        <li data-nav-id="/modules/cds/status/" class="nav-item my-1">
+                
+                 <a href="/modules/cds/status/" class="nav-link p-0">
+                    CDS Status
+                </a>
+        </li>
+        </ul>
+    </li>
+        <li data-nav-id="/modules/circleci/" class="nav-item my-1">
+                
+                 <a href="/modules/circleci/" class="nav-link p-0">
+                    CircleCI
+                </a>
+        </li>
+        <li data-nav-id="/modules/clocks/" class="nav-item my-1">
+                
+                 <a href="/modules/clocks/" class="nav-link p-0">
+                    Clocks
+                </a>
+        </li>
+        <li data-nav-id="/modules/cmdrunner/" class="nav-item my-1">
+                
+                 <a href="/modules/cmdrunner/" class="nav-link p-0">
+                    CmdRunner
+                </a>
+        </li>
+    <li data-nav-id="/modules/cryptocurrencies/" class="nav-item my-1 haschildren
+        ">
+        
+        <a class="nav-link p-0" href="/modules/cryptocurrencies/"><h6>Crypto Currencies</h6></a>
+        <ul class="list-unstyled ml-2">
+        <li data-nav-id="/modules/cryptocurrencies/bittrex/" class="nav-item my-1">
+                
+                 <a href="/modules/cryptocurrencies/bittrex/" class="nav-link p-0">
+                    Bittrex
+                </a>
+        </li>
+        <li data-nav-id="/modules/cryptocurrencies/blockfolio/" class="nav-item my-1">
+                
+                 <a href="/modules/cryptocurrencies/blockfolio/" class="nav-link p-0">
+                    Blockfolio
+                </a>
+        </li>
+        <li data-nav-id="/modules/cryptocurrencies/cryptolive/" class="nav-item my-1">
+                
+                 <a href="/modules/cryptocurrencies/cryptolive/" class="nav-link p-0">
+                    CryptoLive
+                </a>
+        </li>
+        </ul>
+    </li>
+        <li data-nav-id="/modules/datadog/" class="nav-item my-1">
+                
+                 <a href="/modules/datadog/" class="nav-link p-0">
+                    Datadog
+                </a>
+        </li>
+        <li data-nav-id="/modules/devto/" class="nav-item my-1">
+                
+                 <a href="/modules/devto/" class="nav-link p-0">
+                    DEV (dev.to)
+                </a>
+        </li>
+        <li data-nav-id="/modules/digitalclock/" class="nav-item my-1">
+                
+                 <a href="/modules/digitalclock/" class="nav-link p-0">
+                    Digital Clock
+                </a>
+        </li>
+        <li data-nav-id="/modules/digitalocean/" class="nav-item my-1">
+                
+                 <a href="/modules/digitalocean/" class="nav-link p-0">
+                    DigitalOcean
+                </a>
+        </li>
+        <li data-nav-id="/modules/docker/" class="nav-item my-1">
+                
+                 <a href="/modules/docker/" class="nav-link p-0">
+                    Docker
+                </a>
+        </li>
+        <li data-nav-id="/modules/exchange_rates/" class="nav-item my-1">
+                
+                 <a href="/modules/exchange_rates/" class="nav-link p-0">
+                    Exchange Rates
+                </a>
+        </li>
+        <li data-nav-id="/modules/feedreader/" class="nav-item my-1">
+                
+                 <a href="/modules/feedreader/" class="nav-link p-0">
+                    Feed Reader
+                </a>
+        </li>
+        <li data-nav-id="/modules/gerrit/" class="nav-item my-1">
+                
+                 <a href="/modules/gerrit/" class="nav-link p-0">
+                    Gerrit
+                </a>
+        </li>
+        <li data-nav-id="/modules/git/" class="nav-item my-1">
+                
+                 <a href="/modules/git/" class="nav-link p-0">
+                    Git
+                </a>
+        </li>
+        <li data-nav-id="/modules/github/" class="nav-item my-1">
+                
+                 <a href="/modules/github/" class="nav-link p-0">
+                    GitHub
+                </a>
+        </li>
+        <li data-nav-id="/modules/gitlab/" class="nav-item my-1">
+                
+                 <a href="/modules/gitlab/" class="nav-link p-0">
+                    GitLab
+                </a>
+        </li>
+        <li data-nav-id="/modules/gitter/" class="nav-item my-1">
+                
+                 <a href="/modules/gitter/" class="nav-link p-0">
+                    Gitter
+                </a>
+        </li>
+    <li data-nav-id="/modules/google/" class="nav-item my-1 haschildren
+        ">
+        
+        <a class="nav-link p-0" href="/modules/google/"><h6>Google Apps</h6></a>
+        <ul class="list-unstyled ml-2">
+        <li data-nav-id="/modules/google/gcal/" class="nav-item my-1">
+                
+                 <a href="/modules/google/gcal/" class="nav-link p-0">
+                    Google Calendar
+                </a>
+        </li>
+        <li data-nav-id="/modules/google/ganalytics/" class="nav-item my-1">
+                
+                 <a href="/modules/google/ganalytics/" class="nav-link p-0">
+                    Google Analytics
+                </a>
+        </li>
+        <li data-nav-id="/modules/google/gspreadsheet/" class="nav-item my-1">
+                
+                 <a href="/modules/google/gspreadsheet/" class="nav-link p-0">
+                    Google Spreadsheets
+                </a>
+        </li>
+        </ul>
+    </li>
+        <li data-nav-id="/modules/hackernews/" class="nav-item my-1">
+                
+                 <a href="/modules/hackernews/" class="nav-link p-0">
+                    Hacker News
+                </a>
+        </li>
+        <li data-nav-id="/modules/hibp/" class="nav-item my-1">
+                
+                 <a href="/modules/hibp/" class="nav-link p-0">
+                    Have I Been Pwned (HIBP)
+                </a>
+        </li>
+    <li data-nav-id="/modules/ipaddress/" class="nav-item my-1 haschildren
+        ">
+        
+        <a class="nav-link p-0" href="/modules/ipaddress/"><h6>IP Addresses</h6></a>
+        <ul class="list-unstyled ml-2">
+        <li data-nav-id="/modules/ipaddress/ipapi/" class="nav-item my-1">
+                
+                 <a href="/modules/ipaddress/ipapi/" class="nav-link p-0">
+                    IP-API
+                </a>
+        </li>
+        <li data-nav-id="/modules/ipaddress/ipinfo/" class="nav-item my-1">
+                
+                 <a href="/modules/ipaddress/ipinfo/" class="nav-link p-0">
+                    IPInfo
+                </a>
+        </li>
+        </ul>
+    </li>
+        <li data-nav-id="/modules/jenkins/" class="nav-item my-1">
+                
+                 <a href="/modules/jenkins/" class="nav-link p-0">
+                    Jenkins
+                </a>
+        </li>
+        <li data-nav-id="/modules/jira/" class="nav-item my-1">
+                
+                 <a href="/modules/jira/" class="nav-link p-0">
+                    Jira
+                </a>
+        </li>
+        <li data-nav-id="/modules/kubernetes/" class="nav-item my-1">
+                
+                 <a href="/modules/kubernetes/" class="nav-link p-0">
+                    Kubernetes
+                </a>
+        </li>
+        <li data-nav-id="/modules/logger/" class="nav-item my-1">
+                
+                 <a href="/modules/logger/" class="nav-link p-0">
+                    Logger
+                </a>
+        </li>
+        <li data-nav-id="/modules/mercurial/" class="nav-item my-1">
+                
+                 <a href="/modules/mercurial/" class="nav-link p-0">
+                    Mercurial
+                </a>
+        </li>
+        <li data-nav-id="/modules/newrelic/" class="nav-item my-1">
+                
+                 <a href="/modules/newrelic/" class="nav-link p-0">
+                    New Relic
+                </a>
+        </li>
+        <li data-nav-id="/modules/opsgenie/" class="nav-item my-1">
+                
+                 <a href="/modules/opsgenie/" class="nav-link p-0">
+                    OpsGenie
+                </a>
+        </li>
+        <li data-nav-id="/modules/pagerduty/" class="nav-item my-1">
+                
+                 <a href="/modules/pagerduty/" class="nav-link p-0">
+                    Pagerduty
+                </a>
+        </li>
+        <li data-nav-id="/modules/pihole/" class="nav-item my-1">
+                
+                 <a href="/modules/pihole/" class="nav-link p-0">
+                    Pi-hole
+                </a>
+        </li>
+        <li data-nav-id="/modules/pocket/" class="nav-item my-1">
+                
+                 <a href="/modules/pocket/" class="nav-link p-0">
+                    Pocket
+                </a>
+        </li>
+        <li data-nav-id="/modules/power/" class="nav-item my-1">
+                
+                 <a href="/modules/power/" class="nav-link p-0">
+                    Power
+                </a>
+        </li>
+        <li data-nav-id="/modules/resourceusage/" class="nav-item my-1">
+                
+                 <a href="/modules/resourceusage/" class="nav-link p-0">
+                    Resource Usage
+                </a>
+        </li>
+        <li data-nav-id="/modules/rollbar/" class="nav-item my-1">
+                
+                 <a href="/modules/rollbar/" class="nav-link p-0">
+                    Rollbar
+                </a>
+        </li>
+        <li data-nav-id="/modules/security/" class="nav-item my-1">
+                
+                 <a href="/modules/security/" class="nav-link p-0">
+                    Security
+                </a>
+        </li>
+    <li data-nav-id="/modules/sports/" class="nav-item my-1 haschildren
+        ">
+        
+        <a class="nav-link p-0" href="/modules/sports/"><h6>Sports</h6></a>
+        <ul class="list-unstyled ml-2">
+        <li data-nav-id="/modules/sports/football/" class="nav-item my-1">
+                
+                 <a href="/modules/sports/football/" class="nav-link p-0">
+                    Football
+                </a>
+        </li>
+        <li data-nav-id="/modules/sports/nbascore/" class="nav-item my-1">
+                
+                 <a href="/modules/sports/nbascore/" class="nav-link p-0">
+                    NBA Score
+                </a>
+        </li>
+        </ul>
+    </li>
+        <li data-nav-id="/modules/spotify/" class="nav-item my-1">
+                
+                 <a href="/modules/spotify/" class="nav-link p-0">
+                    Spotify
+                </a>
+        </li>
+        <li data-nav-id="/modules/subreddit/" class="nav-item my-1">
+                
+                 <a href="/modules/subreddit/" class="nav-link p-0">
+                    Subreddit
+                </a>
+        </li>
+        <li data-nav-id="/modules/textfile/" class="nav-item my-1">
+                
+                 <a href="/modules/textfile/" class="nav-link p-0">
+                    Textfile
+                </a>
+        </li>
+        <li data-nav-id="/modules/todo/" class="nav-item my-1">
+                
+                 <a href="/modules/todo/" class="nav-link p-0">
+                    Todo
+                </a>
+        </li>
+        <li data-nav-id="/modules/todoist/" class="nav-item my-1">
+                
+                 <a href="/modules/todoist/" class="nav-link p-0">
+                    Todoist
+                </a>
+        </li>
+        <li data-nav-id="/modules/transmission/" class="nav-item my-1">
+                
+                 <a href="/modules/transmission/" class="nav-link p-0">
+                    Transmission
+                </a>
+        </li>
+        <li data-nav-id="/modules/travisci/" class="nav-item my-1">
+                
+                 <a href="/modules/travisci/" class="nav-link p-0">
+                    TravisCI
+                </a>
+        </li>
+        <li data-nav-id="/modules/trello/" class="nav-item my-1">
+                
+                 <a href="/modules/trello/" class="nav-link p-0">
+                    Trello
+                </a>
+        </li>
+    <li data-nav-id="/modules/twitter/" class="nav-item my-1 haschildren
+        ">
+        
+        <a class="nav-link p-0" href="/modules/twitter/"><h6>Twitter</h6></a>
+        <ul class="list-unstyled ml-2">
+        <li data-nav-id="/modules/twitter/twitterstats/" class="nav-item my-1">
+                
+                 <a href="/modules/twitter/twitterstats/" class="nav-link p-0">
+                    Twitter Stats
+                </a>
+        </li>
+        <li data-nav-id="/modules/twitter/twittertweets/" class="nav-item my-1">
+                
+                 <a href="/modules/twitter/twittertweets/" class="nav-link p-0">
+                    Twitter
+                </a>
+        </li>
+        </ul>
+    </li>
+        <li data-nav-id="/modules/uptime_robot/" class="nav-item my-1">
+                
+                 <a href="/modules/uptime_robot/" class="nav-link p-0">
+                    UptimeRobot
+                </a>
+        </li>
+        <li data-nav-id="/modules/victorops/" class="nav-item my-1">
+                
+                 <a href="/modules/victorops/" class="nav-link p-0">
+                    VictorOps OnCall
+                </a>
+        </li>
+    <li data-nav-id="/modules/weather_services/" class="nav-item my-1 parent active haschildren
+        ">
+        
+        <a class="nav-link p-0" href="/modules/weather_services/"><h6>Weather Services</h6></a>
+        <ul class="list-unstyled ml-2">
+        <li data-nav-id="/modules/weather_services/arpansagovau/" class="nav-item my-1">
+                
+                 <a href="/modules/weather_services/arpansagovau/" class="nav-link p-0">
+                    ARPANSA
+                </a>
+        </li>
+        <li data-nav-id="/modules/weather_services/prettyweather/" class="nav-item my-1">
+                
+                 <a href="/modules/weather_services/prettyweather/" class="nav-link p-0">
+                    Pretty Weather
+                </a>
+        </li>
+        <li data-nav-id="/modules/weather_services/weather/" class="nav-item my-1">
+                
+                 <a href="/modules/weather_services/weather/" class="nav-link p-0">
+                    Weather
+                </a>
+        </li>
+        </ul>
+    </li>
+        <li data-nav-id="/modules/zendesk/" class="nav-item my-1">
+                
+                 <a href="/modules/zendesk/" class="nav-link p-0">
+                    Zendesk
+                </a>
+        </li>
         </ul>
     </li>
     <li data-nav-id="/blog/" class="nav-item my-1 haschildren

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -510,22 +510,16 @@
         
         <a class="nav-link p-0" href="/modules/twitter/"><h6>Twitter</h6></a>
         <ul class="list-unstyled ml-2">
-        <li data-nav-id="/modules/weather_services/arpansagovau/" class="nav-item my-1">
+        <li data-nav-id="/modules/twitter/twitterstats/" class="nav-item my-1">
                 
-                 <a href="/modules/weather_services/arpansagovau/" class="nav-link p-0">
-                    ARPANSA
+                 <a href="/modules/twitter/twitterstats/" class="nav-link p-0">
+                    Twitter Stats
                 </a>
         </li>
-        <li data-nav-id="/modules/weather_services/prettyweather/" class="nav-item my-1">
+        <li data-nav-id="/modules/twitter/twittertweets/" class="nav-item my-1">
                 
-                 <a href="/modules/weather_services/prettyweather/" class="nav-link p-0">
-                    Pretty Weather
-                </a>
-        </li>
-        <li data-nav-id="/modules/weather_services/weather/" class="nav-item my-1">
-                
-                 <a href="/modules/weather_services/weather/" class="nav-link p-0">
-                    Weather
+                 <a href="/modules/twitter/twittertweets/" class="nav-link p-0">
+                    Twitter
                 </a>
         </li>
         </ul>


### PR DESCRIPTION
On https://wtfutil.com/ main page, "Weather" module directs to broken path https://wtfutil.com/modules/weather/ which results with an Error 404.

Updating the path from `/modules/weather/` to `/modules/weather_services/weather/`.