### PR TITLE
Update healthchecks.md

### DIFF
--- a/docs/modules/healthchecks.md
+++ b/docs/modules/healthchecks.md
@@ -7,8 +7,9 @@ Connect to the [Healthchecks](https://healthchecks.io) API.
 ```yaml
 healthchecks:
   type: healthchecks
+  enabled: true
   apiKey: "XXXX"
-  apiURL: "https://hc-ping.com/"
+  apiURL: "https://healthchecks.io/"
   tags:
     - backup
   position:
@@ -37,7 +38,7 @@ healthchecks:
             {% include "attributes/custom.md" %}
         {% endwith %}
 
-        {% with name="apiURL", desc="<em>Optional</em> Healthchecks API URL. Default: <code>https://hc-ping.com/</code>", value="string" %}
+        {% with name="apiURL", desc="<em>Optional</em> Healthchecks API URL. Default: <code>https://healthchecks.io/</code>", value="string" %}
             {% include "attributes/custom.md" %}
         {% endwith %}
 


### PR DESCRIPTION
Default URL of the service has changed.
- According to https://healthchecks.io/docs/api/ the management URL base is now healthchecks.io
The sample yaml config needs to have enable=True by default.