### PR TITLE
Updated repo_url to fix 'Edit this page' links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_author: Chris Cummer
 
 # Source code repository
 repo_name: wtfutil/wtf
-repo_url: https://github.com/wtfutil/wtf
+repo_url: https://github.com/wtfutil/wtfdocs
 
 # Copyright
 copyright: Copyright &copy; 2020 Chris Cummer


### PR DESCRIPTION
Config change to fix the "Edit this page" link on every wiki page:

![image](https://user-images.githubusercontent.com/3665694/137230848-25751c7b-0b7c-4ea1-9db2-a19c1ac938b9.png)
