### PR TITLE
Fixed git repo stats on top right of page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,8 @@ site_author: Chris Cummer
 
 # Source code repository
 repo_name: wtfutil/wtf
-repo_url: https://github.com/wtfutil/wtfdocs
+repo_url: https://github.com/wtfutil/wtf
+edit_uri: https://github.com/wtfutil/wtfdocs/edit/master/docs
 
 # Copyright
 copyright: Copyright &copy; 2020 Chris Cummer


### PR DESCRIPTION
Resolved issue with repo stats being from wtfutil/wtfdocs and not wtfutil/wtf.

Before:
![image](https://user-images.githubusercontent.com/3665694/137649100-c0245d94-6729-43d8-b3e4-dff22936c911.png)

After:
![image](https://user-images.githubusercontent.com/3665694/137649092-975ee8d4-7c72-42c4-9a7a-8fe08a45e940.png)
