### PR TITLE
Added requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs
+mkdocs-material
+mkdocs-macros-plugin


### PR DESCRIPTION
Added requirements.txt as I always forget that I need to install `mkdocs-macros-plugin`

Contents of requirements.txt:
 - mkdocs
 - mkdocs-material
 - mkdocs-macros-plugin

Listing mkdocs is a bit redundant but ensures that the correct version of Markdown is installed when using venv.