### PR TITLE
Power module: added dependencies

### DIFF
--- a/docs/modules/power.md
+++ b/docs/modules/power.md
@@ -23,3 +23,17 @@ power:
 
 {% set src="power" %}
 {% include "src_path.md" %}
+
+## Dependencies
+
+### Linux
+
+[upower](https://upower.freedesktop.org/)
+
+### FreeBSD
+
+[apm](https://www.freebsd.org/cgi/man.cgi?apm)
+
+### MacOS
+
+[pmset](https://en.wikipedia.org/wiki/Pmset)


### PR DESCRIPTION
As mentioned on #162, the power module relies on an external command that needs to be installed in the system; this command varies depending on the OS.

This PR specifies the dependencies in the module's documentation.

