### PR TITLE
feat(config): document the possibility to set the configuration path from `WTF_CONFIG`

### DIFF
--- a/docs/configuration/files.md
+++ b/docs/configuration/files.md
@@ -38,3 +38,10 @@ parameter on launch:
 ```bash
 ❯ wtfutil --config=path/to/custom/config.yml
 ```
+
+You can also specify this configuration using hte `WTF_CONFIG` environment variables:
+
+```bash
+❯ export WTF_CONFIG=path/to/custom/config.yml
+❯ wtfutil
+```


### PR DESCRIPTION
This PR document the possibility to set the configuration path from `WTF_CONFIG` introduced in wtfutil/wtf#1572.