### PR TITLE
Add Windows activation instructions for virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,21 @@ This site is built using [Material for MkDocs](https://squidfunk.github.io/mkdoc
 
 ### Development environment setup
 
-1. Install python 3
-2. Create a virtual-env:
+**1. Install python 3**
+
+**2. Create and activate a virtual-env:**
+ - *Linux/macOS:*
 ```bash
 python -m venv virtual-env
 source virtual-env/bin/activate
 ```
-3. `pip install -r requirements.txt`
-4. `mkdocs serve`
+ - *Windows:*
+```bash
+python -m venv virtual-env
+virtual-env\Scripts\activate
+```
+**3. `pip install -r requirements.txt`**
+**4. `mkdocs serve`**
 
 ### To add documentation for a new module
 


### PR DESCRIPTION
Greetings team!

I noticed the development setup instructions in the README only provided the `source` command for activating the virtual environment, which doesn't work on Windows.

Since WTF is a cross-platform terminal dashboard, I added the corresponding Windows command (`virtual-env\Scripts\activate`) to ensure contributors on all platforms can get their local dev environment running smoothly without hitting a "command not found" error.

**Changes:**
- Split step 2 into Linux/macOS and Windows sections.
- Added the correct activation path for Windows users.

Hope this helps lower the barrrier for new contributors on Windows!